### PR TITLE
Simplify sentence-end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 checks: tests test-sentence-ends
 
 test-sentence-ends:
-	errors=$$(grep -n '[^0-9]\. [^ lswxz.,"(]' MANUAL.org); echo "$$errors"; [ -z "$$errors" ]
-	errors=$$(grep -n '\. [^ a]' README.org CHANGES.org LICENSE.org); echo "$$errors"; [ -z "$$errors" ]
-	errors=$$(grep -n '\. [^ m]' *.el); echo "$$errors"; [ -z "$$errors" ]
-	errors=$$(grep -n '[?!] [^ ]' *.org *.el); echo "$$errors"; [ -z "$$errors" ]
+	grep -n '[^0-9]\. [^ lswxz.,"(]' MANUAL.org; [ $$? = 1 ]
+	grep -n '\. [^ a]' README.org CHANGES.org LICENSE.org; [ $$? = 1 ]
+	grep -n '\. [^ m]' *.el; [ $$? = 1 ]
+	grep -n '[?!] [^ ]' *.org *.el; [ $$? = 1 ]
 
 tests:
 	emacs --batch -l devil.el -l devil-tests.el -f ert-run-tests-batch-and-exit


### PR DESCRIPTION
Remove sub-shells and variables, and instead just check the return code.  A return code of 1 means that nothing matched and there was no error.

Note: This is fairly trivial change which should be functionally equivalent, I just thought it made the lines easier to read. Feel free to close the PR, apply the same change yourself, or ignore the suggestion entirely.