### PR TITLE
Allow user defined keys in translation rules

### DIFF
--- a/devil.el
+++ b/devil.el
@@ -475,7 +475,7 @@ match is found, it is replaced with its corresponding binding."
   (catch 'break
     (dolist (chunk (split-string translated-key " "))
       (when (or (string= chunk "")
-                (not (string-match-p "^\\(?:[ACHMSs]-\\)*[^-]*$" chunk))
+                (not (string-match-p "^\\(?:[ACHMSs]-\\)*\\([^-]*\\|<.*>\\)$" chunk))
                 (string-match-p "\\([ACHMSs]-\\)[^ ]*\\1" chunk))
         (throw 'break t)))))
 


### PR DESCRIPTION
Fixed an issue where devil wouldn't work with user defined keys with a `-` in them.

Examples of popular user defined keys include `<C-i>`, `<C-m>`, and `<control-x>`.