### PR TITLE
Add option to set devil-mode in all buffers

### DIFF
--- a/CHANGES.org
+++ b/CHANGES.org
@@ -16,6 +16,9 @@
 - Repeatable key sequence group for =, x ^= and =, x {= and =, x }=.
 - Repeatable key sequences =, a= and =, e= added to group for =, p=.
 - Repeatable key sequences =, m a= and =, m e= added to group for =, m b=.
+- Customisable variable =devil-global-sets-buffer-default= that, when
+  set to =t=, makes enabling =global-devil-mode= also enable Devil in
+  all new buffers.
 
 *** Changed
 

--- a/MANUAL.org
+++ b/MANUAL.org
@@ -510,6 +510,48 @@ a text buffer like this, although we can type =, x , f= to launch the
 minibuffer.  Further the special keymaps described in the previous
 section work only when Devil is enabled globally.
 
+** Mode as a buffer default
+:PROPERTIES:
+:CUSTOM_ID: buffer-default
+:END:
+While enabling =global-devil-mode= is typically enough for using Devil
+in every buffer the user encounters, buffer creation which bypasses
+the traditional setup hooks will not have the mode enabled by default.
+The most likely place to encounter this problem is with the default
+Emacs startup screen, which is created after the user's init file has
+been processed but does not run any hooks which will enable Devil.
+
+To solve this particular problem it is recommended to either customise
+the startup screen to one which does run the required hooks, or to
+advise the =display-startup-screen= function to enable Devil in the
+buffer once created.  Here is an example of enabling
+=global-devil-mode= and ensuring it is activated in the default Emacs
+startup screen.
+
+#+begin_src elisp
+  (require 'devil)
+  (global-devil-mode)
+  (advice-add 'display-startup-screen
+              :after (lambda (&optional _) (devil-mode 1)))
+#+end_src
+
+This solves the problem most likely to be encountered.  But what if
+you do genuinely need Devil active in *every* buffer?  When
+=devil-global-sets-buffer-default= is set to =t= and
+=global-minor-mode= is called, Devil will be enabled in all new
+buffers by default.  Enabling this functionality may seem appealing,
+but consider that not all buffers are intended to be interacted with,
+and the decision to opt-out of hooks which could apply a minor-mode is
+likely to have been intentional.  Even though it is not recommended,
+the following example demonstrates how to have Devil active in all
+buffers by default.
+
+#+begin_src elisp
+  (require 'devil)
+  (setq devil-global-sets-buffer-default t)
+  (global-devil-mode)
+#+end_src
+
 ** Custom Appearance
 :PROPERTIES:
 :CUSTOM_ID: custom-appearance
@@ -966,6 +1008,16 @@ and preferences.
     others may find god-mode easier to use.  See the section
     [[*Comparison with God Mode]] for more details on the differences
     between the two modes.
+
+05. I've called the function =global-devil-mode= in my config file,
+    but when Emacs opens Devil does not seem to active.  Why isn't it
+    working?
+
+    The most likely issue is that the first buffer shown is the
+    default Emacs startup screen, which is created without running any
+    hooks which would give Devil the opportunity to be applied.  See
+    the section [[*Mode as a buffer default]] for further details and
+    possible solutions.
 
 * Conclusion
 :PROPERTIES:

--- a/devil.el
+++ b/devil.el
@@ -227,6 +227,26 @@ Format control sequences supported by `devil-format' may be used
 in the format control string."
   :type 'string)
 
+(defcustom devil-global-sets-buffer-default nil
+  "Non-nil iff `global-devil-mode' modifies new buffer defaults.
+
+When non-nil and `global-devil-mode' is enabled, `devil-mode'
+will be enabled in all new buffers without relying on the
+standard global minor-mode hooks.
+
+While this solves issues with `devil-mode' not being active in
+buffers which have not called the hooks where a minor-mode could
+be applied, the decision to bypass these hooks is likely to have
+been intentional.  It is not recommended to enable this option
+unless you are absolutely sure of the consequences.
+
+To work around the most common issue, where `global-devil-mode'
+is enabled during start-up but `devil-mode' is not enabled in the
+default Emacs startup screen, a safer solution is to advise the
+function which creates the startup screen to enable the mode
+locally."
+  :type 'boolean)
+
 
 ;;; Minor Mode Definition ============================================
 
@@ -239,7 +259,9 @@ in the format control string."
 ;;;###autoload
 (define-globalized-minor-mode
   global-devil-mode devil-mode devil--on
-  (if global-devil-mode (devil--add-extra-keys) (devil--remove-extra-keys)))
+  (if global-devil-mode (devil--add-extra-keys) (devil--remove-extra-keys))
+  (when devil-global-sets-buffer-default
+    (setq-default devil-mode global-devil-mode)))
 
 (defun devil--on ()
   "Turn Devil mode on."


### PR DESCRIPTION
This is an attempt to workaround the issues where calling `global-devil-mode` from the user's config file is not enough to get Devil working in all buffers that the user interacts with. This appears to happen because the hook functions added by enabling the global mode are not guaranteed be run, most likely for buffers which are either meant to be protected from such hooks during startup, or are not intended for the user to interact with.

The most basic demonstration of the problem would be something like this, where you will end up in a new buffer where `devil-mode` is not enabled:
```elisp
(switch-to-buffer (get-buffer-create "my buffer"))
```

I believe this is by design and described in the documentation for `define-globalized-minor-mode`:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Defining-Minor-Modes.html
> Globally enabling the mode also affects buffers subsequently created by visiting files, and buffers that use a major mode other than Fundamental mode; but it does not detect the creation of a new buffer in Fundamental mode. 

...I think that what this means is, at the most basic level of creating the buffer, there are no hooks being run which would allow a global minor-mode to apply.

I've added functionality which modifies the the default value of `devil-mode` using `setq-default`, and this seems to be a solution to the problem, but the use of such a feature is probably not be be encouraged too much. As such, I've also added an example to the manual which describes a workaround for the most common problem and suggested that this is the better solution in most cases.

I've also only done limited testing.

Feel free to close this PR if you feel the feature is a bad idea. If the definition of the global minor-mode were later to include a `:predicate` value (which would introduce a `devil-global-modes` variable meant to control where the mode will be applied), the two would conflict. Perhaps just documenting the workaround for the default startup screen is enough of a fix.

Fixes #20