### PR TITLE
Fix installation and use of manual for NonGNU ELPA

### DIFF
--- a/MANUAL.org
+++ b/MANUAL.org
@@ -4,7 +4,7 @@
 #+language:             en
 #+options:              ':t toc:nil author:t email:t num:t
 #+texinfo_dir_category: Emacs misc features
-#+texinfo_dir_title:    Devil: (devil-mode)
+#+texinfo_dir_title:    Devil: (devil)
 #+texinfo_dir_desc:     Minor mode for Devil-like command entering
 
 #+texinfo: @insertcopying

--- a/MANUAL.org
+++ b/MANUAL.org
@@ -6,6 +6,7 @@
 #+texinfo_dir_category: Emacs misc features
 #+texinfo_dir_title:    Devil: (devil)
 #+texinfo_dir_desc:     Minor mode for Devil-like command entering
+#+export_file_name:     devil
 
 #+texinfo: @insertcopying
 


### PR DESCRIPTION
This makes two changes to fix the installation and usage of the manual:
- the export name is now configured as "devil" (it exports as "devil.texi" and "devil.info" when using the Org exporters)
- the Info dir title has been renamed to match the package name rather than the mode name

I've tested that the NonGNU ELPA admin scripts will now package the manual as "devil.info" and that after installation it is possible to view the manual in Emacs using `(info)`.

I have made no checks regarding MELPA.

Fixes #17