### PR TITLE
Fix errors in devil-repeatable-keys

### DIFF
--- a/devil.el
+++ b/devil.el
@@ -167,7 +167,6 @@ by `devil-format' may be used in the keys and values."
     ("%k d")
     ("%k k")
     ("%k m ^")
-    ("%k m e")
     ("%k m b" "%k m f" "%k m a" "%k m e")
     ("%k m @" "%k m h")
     ("%k m y")

--- a/devil.el
+++ b/devil.el
@@ -168,7 +168,7 @@ by `devil-format' may be used in the keys and values."
     ("%k k")
     ("%k m ^")
     ("%k m e")
-    ("%k m b" "%k m f" "%k m a" "% k m e")
+    ("%k m b" "%k m f" "%k m a" "%k m e")
     ("%k m @" "%k m h")
     ("%k m y")
     ("%k p" "%k n" "%k b" "%k f" "%k a" "%k e")


### PR DESCRIPTION
This fixes a duplicate entry and typo for the repeat setup of `forward-sentence`.

Fixes #23 