### PR TITLE
Autoload `devil-set-key` and `devil-describe-key`

### DIFF
--- a/devil.el
+++ b/devil.el
@@ -85,6 +85,7 @@ sequence given in VALUE activates Devil."
   (define-key devil-mode-map value #'devil)
   (devil--log "Keymap updated to %s" devil-mode-map))
 
+;;;###autoload
 (defun devil-set-key (key)
   "Set `devil-key' to the given KEY and update `devil-mode-map'.
 
@@ -312,6 +313,7 @@ locally."
       (when translated-key
         (devil--set-repeatable-keys (key-description key))))))
 
+;;;###autoload
 (defun devil-describe-key ()
   "Describe a Devil key sequence."
   (interactive)


### PR DESCRIPTION
Both of these might be the first function called from the package, so they might as well autoload it.  With this change, a user is free to call `devil-set-key` before `global-devil-mode` in their init file.